### PR TITLE
Declare cell size as a constant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ html/
 .idea/
 # Ignore Mac files
 .DS_Store
+cmake-*/

--- a/mazerunner/config.h
+++ b/mazerunner/config.h
@@ -68,6 +68,10 @@ const float ROTATION_BIAS = 0.0025; // Negative makes robot curve to left
 
 //***************************************************************************//
 
+// This is the size fo each cell in the maze. Normally 180mm for a classic maze
+const float FULL_CELL = 180.0f;
+const float HALF_CELL = FULL_CELL / 2.0;
+
 //***************************************************************************//
 // Battery resistor bridge //Derek Hall//
 // The battery measurement is performed by first reducing the battery voltage

--- a/mazerunner/mouse.cpp
+++ b/mazerunner/mouse.cpp
@@ -78,7 +78,7 @@ void print_walls() {
  * TODO: need a function just to adjust forward position
  */
 static void stopAndAdjust() {
-  float remaining = 270 - forward.position();
+  float remaining = (FULL_CELL + HALF_CELL) - forward.position();
   disable_steering();
   forward.start(remaining, forward.speed(), 0, forward.acceleration());
   while (not forward.is_finished()) {
@@ -131,7 +131,7 @@ void Mouse::end_run() {
   bool has_wall = frontWall;
   disable_steering();
   log_status('T');
-  float remaining = 270 - forward.position();
+  float remaining = (FULL_CELL + HALF_CELL) - forward.position();
   forward.start(remaining, forward.speed(), 30, forward.acceleration());
   if (has_wall) {
     while (get_front_sensor() < 850) {
@@ -173,7 +173,7 @@ void Mouse::turn_SS90ER() {
   float alpha = 4000;   // deg/s/s
   bool triggered = false;
   disable_steering();
-  float distance = 190.0 + run_in - forward.position();
+  float distance = FULL_CELL + 10.0 + run_in - forward.position();
   forward.start(distance, forward.speed(), DEFAULT_TURN_SPEED, SEARCH_ACCELERATION);
   while (not forward.is_finished()) {
     delay(2);
@@ -195,7 +195,7 @@ void Mouse::turn_SS90ER() {
   while (not forward.is_finished()) {
     delay(2);
   }
-  forward.set_position(170);
+  forward.set_position(FULL_CELL - 10);
 }
 
 void Mouse::turn_SS90EL() {
@@ -206,7 +206,7 @@ void Mouse::turn_SS90EL() {
   float alpha = 4000;   // deg/s/s
   bool triggered = false;
   disable_steering();
-  float distance = 190.0 + run_in - forward.position();
+  float distance = FULL_CELL + 10.0 + run_in - forward.position();
   forward.start(distance, forward.speed(), DEFAULT_TURN_SPEED, SEARCH_ACCELERATION);
   while (not forward.is_finished()) {
     delay(2);
@@ -228,7 +228,7 @@ void Mouse::turn_SS90EL() {
   while (not forward.is_finished()) {
     delay(2);
   }
-  forward.set_position(170);
+  forward.set_position(FULL_CELL - 10);
 }
 
 /**
@@ -247,7 +247,7 @@ void Mouse::turn_around() {
   bool has_wall = frontWall;
   disable_steering();
   log_status('A');
-  float remaining = 270 - forward.position();
+  float remaining = (FULL_CELL + HALF_CELL) - forward.position();
   forward.start(remaining, forward.speed(), 30, forward.acceleration());
   if (has_wall) {
     while (get_front_sensor() < FRONT_REFERENCE) {
@@ -265,7 +265,7 @@ void Mouse::turn_around() {
   while (not forward.is_finished()) {
     delay(2);
   }
-  forward.set_position(170);
+  forward.set_position(FULL_CELL - 10);
 }
 
 //***************************************************************************//
@@ -322,9 +322,9 @@ void Mouse::follow_to(unsigned char target) {
   while (not forward.is_finished()) {
     delay(2);
   }
-  forward.set_position(90);
+  forward.set_position(HALF_CELL);
   Serial.println(F("Off we go..."));
-  wait_until_position(170);
+  wait_until_position(FULL_CELL - 10);
   // at the start of this loop we are always at the sensing point
   while (location != target) {
     if (button_pressed()) {
@@ -351,9 +351,9 @@ void Mouse::follow_to(unsigned char target) {
       heading = (heading + 3) & 0x03;
       log_status('x');
     } else if (!frontWall) {
-      forward.adjust_position(-180);
+      forward.adjust_position(-FULL_CELL);
       log_status('F');
-      wait_until_position(170);
+      wait_until_position(FULL_CELL - 10.0);
       log_status('x');
     } else if (!rightWall) {
       turn_SS90ER();
@@ -440,9 +440,9 @@ int Mouse::search_to(unsigned char target) {
   while (not forward.is_finished()) {
     delay(2);
   }
-  forward.set_position(90);
+  forward.set_position(HALF_CELL);
   Serial.println(F("Off we go..."));
-  wait_until_position(170);
+  wait_until_position(FULL_CELL - 10);
   // TODO. the robot needs to start each iteration at the sensing point
   while (location != target) {
     if (button_pressed()) {
@@ -469,9 +469,9 @@ int Mouse::search_to(unsigned char target) {
 
       switch (hdgChange) {
         case 0: // ahead
-          forward.adjust_position(-180);
+          forward.adjust_position(-FULL_CELL);
           log_status('F');
-          wait_until_position(170);
+          wait_until_position(FULL_CELL - 10);
           log_status('x');
           break;
         case 1: // right
@@ -513,7 +513,7 @@ int Mouse::search_to(unsigned char target) {
 // run-length encoding of straights is done on the fly.
 // turns are in-place so the mouse stops after each straight.
 //--------------------------------------------------------------------------
-void Mouse::run_in_place_turns(int topSpeed) { //TODO
+void Mouse::run_in_place_turns(int topSpeed) { // TODO
   expand_path(path);
   // debug << path << endl;
   // debug << commands << endl;
@@ -530,20 +530,20 @@ void Mouse::run_in_place_turns(int topSpeed) { //TODO
       index++;
     } else if (commands[index] == 'H' && commands[index + 1] == 'R' && commands[index + 2] == 'H') {
 
-      move_forward(90, topSpeed, 0);
+      move_forward(HALF_CELL, topSpeed, 0);
       turn_IP90R();
-      move_forward(90, topSpeed, topSpeed);
+      move_forward(HALF_CELL, topSpeed, topSpeed);
       index += 3;
     } else if (commands[index] == 'H' && commands[index + 1] == 'L' && commands[index + 2] == 'H') {
-      move_forward(90, topSpeed, 0);
+      move_forward(HALF_CELL, topSpeed, 0);
       turn_IP90L();
-      move_forward(90, topSpeed, topSpeed);
+      move_forward(HALF_CELL, topSpeed, topSpeed);
       index += 3;
     } else if (commands[index] == 'H' && commands[index + 1] == 'H') {
-      move_forward(90, topSpeed, topSpeed);
+      move_forward(HALF_CELL, topSpeed, topSpeed);
       index++;
     } else if (commands[index] == 'H' && commands[index + 1] == 'S') {
-      move_forward(90, topSpeed, 0);
+      move_forward(HALF_CELL, topSpeed, 0);
       index++;
     } else {
       // debug << F("Instruction error!\n");
@@ -590,12 +590,12 @@ void Mouse::run_smooth_turns(int topSpeed) {
       index += 3;
     } else if (commands[index] == 'H' && commands[index + 1] == 'H') {
       // debug << 'H';
-      move_forward(90, topSpeed, topSpeed);
+      move_forward(HALF_CELL, topSpeed, topSpeed);
       ;
       index++;
     } else if (commands[index] == 'H' && commands[index + 1] == 'S') {
       // debug << 'H';
-      move_forward(90, topSpeed, 0);
+      move_forward(HALF_CELL, topSpeed, 0);
       index++;
     } else {
       // debug << F("Instruction error!\n");

--- a/mazerunner/mouse.cpp
+++ b/mazerunner/mouse.cpp
@@ -195,7 +195,7 @@ void Mouse::turn_SS90ER() {
   while (not forward.is_finished()) {
     delay(2);
   }
-  forward.set_position(FULL_CELL - 10);
+  forward.set_position(FULL_CELL - 10.0);
 }
 
 void Mouse::turn_SS90EL() {
@@ -228,7 +228,7 @@ void Mouse::turn_SS90EL() {
   while (not forward.is_finished()) {
     delay(2);
   }
-  forward.set_position(FULL_CELL - 10);
+  forward.set_position(FULL_CELL - 10.0);
 }
 
 /**
@@ -261,11 +261,11 @@ void Mouse::turn_around() {
   // Be sure robot has come to a halt.
   forward.stop();
   spin_turn(-180, SPEEDMAX_SPIN_TURN, SPIN_TURN_ACCELERATION);
-  forward.start(80, SPEEDMAX_EXPLORE, SPEEDMAX_EXPLORE, SEARCH_ACCELERATION);
+  forward.start(HALF_CELL - 10.0, SPEEDMAX_EXPLORE, SPEEDMAX_EXPLORE, SEARCH_ACCELERATION);
   while (not forward.is_finished()) {
     delay(2);
   }
-  forward.set_position(FULL_CELL - 10);
+  forward.set_position(FULL_CELL - 10.0);
 }
 
 //***************************************************************************//

--- a/mazerunner/tests.cpp
+++ b/mazerunner/tests.cpp
@@ -172,7 +172,7 @@ void test_spin_turn(float angle) {
  * @brief perform 1000mm forward or reverse move
  */
 void test_fwd_move() {
-  float distance_a = 720.0;                 // mm
+  float distance_a = 3 * FULL_CELL;         // mm
   float distance_b = FULL_CELL + HALF_CELL; // mm
   float max_speed_a = 800.0;                // mm/s
   float common_speed = 300.0;               // mm/s
@@ -476,7 +476,7 @@ void test_edge_detection() {
   enable_motor_controllers();
   disable_steering();
   Serial.println(F("Edge positions:"));
-  forward.start(150, 100, 0, 1000);
+  forward.start(FULL_CELL - 30.0, 100, 0, 1000);
   while (not forward.is_finished()) {
     if (g_left_wall_sensor > left_max) {
       left_max = g_left_wall_sensor;

--- a/mazerunner/tests.cpp
+++ b/mazerunner/tests.cpp
@@ -172,13 +172,13 @@ void test_spin_turn(float angle) {
  * @brief perform 1000mm forward or reverse move
  */
 void test_fwd_move() {
-  float distance_a = 720.0;      // mm
-  float distance_b = 270.0;      // mm
-  float max_speed_a = 800.0;     // mm/s
-  float common_speed = 300.0;    // mm/s
-  float max_speed_b = 500.0;     // mm/s
-  float acceleration_a = 2000.0; // mm/s/s
-  float acceleration_b = 1000.0; // mm/s/s
+  float distance_a = 720.0;                 // mm
+  float distance_b = FULL_CELL + HALF_CELL; // mm
+  float max_speed_a = 800.0;                // mm/s
+  float common_speed = 300.0;               // mm/s
+  float max_speed_b = 500.0;                // mm/s
+  float acceleration_a = 2000.0;            // mm/s/s
+  float acceleration_b = 1000.0;            // mm/s/s
   reset_drive_system();
   enable_motor_controllers();
   report_profile_header();
@@ -201,9 +201,9 @@ void test_fwd_move() {
  */
 
 void test_sprint_and_return() {
-  float distance = 3 * 180.0;  // mm
-  float max_speed = 1200.0;    // mm/s
-  float acceleration = 2000.0; // mm/s/s
+  float distance = 3 * FULL_CELL; // mm
+  float max_speed = 1200.0;       // mm/s
+  float acceleration = 2000.0;    // mm/s/s
   reset_drive_system();
   enable_motor_controllers();
   report_profile_header();
@@ -343,9 +343,9 @@ void test_stop_at() {
  */
 void test_sprint_with_steering() {
   // sensor calibration
-  float distance = 5 * 180.0;  // mm
-  float max_speed = 800.0;     // mm/s
-  float acceleration = 2000.0; // mm/s/s
+  float distance = 5 * FULL_CELL; // mm
+  float max_speed = 800.0;        // mm/s
+  float acceleration = 2000.0;    // mm/s/s
   enable_sensors();
   reset_drive_system();
   enable_steering();

--- a/mazerunner/user.cpp
+++ b/mazerunner/user.cpp
@@ -171,10 +171,10 @@ void run_mouse(int function) {
       while (not forward.is_finished()) {
         delay(2);
       }
-      // forward.set_position(90);
+      // forward.set_position(HALF_CELL);
       // Serial.println(F("Off we go..."));
-      // // wait_until_position(170);
-      // stop_at(170);
+      // // wait_until_position(FULL_CELL-10);
+      // stop_at(FULL_CELL-10);
       Serial.print('@');
       print_justified((int)forward.position(), 4);
       Serial.print(' ');
@@ -188,10 +188,10 @@ void run_mouse(int function) {
       while (not forward.is_finished()) {
         delay(2);
       }
-      // forward.set_position(90);
+      // forward.set_position(HALF_CELL);
       // Serial.println(F("Off we go..."));
-      // // wait_until_position(170);
-      // stop_at(170);
+      // // wait_until_position(FULL_CELL-10);
+      // stop_at(FULL_CELL-10);
       Serial.print('@');
       print_justified((int)forward.position(), 4);
       Serial.print(' ');
@@ -202,7 +202,7 @@ void run_mouse(int function) {
       reset_drive_system();
       enable_motor_controllers();
       report_profile_header();
-      forward.start(180, 180, 30, 1000);
+      forward.start(FULL_CELL, 180, 30, 1000);
       while (not forward.is_finished()) {
         report_profile();
       }


### PR DESCRIPTION
Many places in the code had distances expressed as magic numbers related to the cell size. This change is intended to make the cell size a configuration constant so that the code is more readily modified for other cell sizes.